### PR TITLE
Update accessibility guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-a11y-checker
 
-jupyterLab-a11y-checker is a JupyterLab extension that helps authors detect and fix accessibility issues in Jupyter Notebooks, aligning with WCAG 2.0 AA guidelines. It enables authors to identify accessibility issues in their notebooks and provides actionable suggestions to fix them. It combines the strengths of [axe-core](https://github.com/dequelabs/axe-core), a widely used accessibility engine, with custom notebook-specific detection algorithms that address issues axe cannot reliably cover in JupyterLab.
+jupyterLab-a11y-checker is a JupyterLab extension that helps authors detect and fix accessibility issues in Jupyter Notebooks, aligning with WCAG 2.1 AA guidelines. It enables authors to identify accessibility issues in their notebooks and provides actionable suggestions to fix them. It combines the strengths of [axe-core](https://github.com/dequelabs/axe-core), a widely used accessibility engine, with custom notebook-specific detection algorithms that address issues axe cannot reliably cover in JupyterLab.
 
 Here's how the extension looks like:
 


### PR DESCRIPTION
Updated WCAG guidelines reference from 2.0 AA to 2.1 AA.

@Chanbinski I didn't see any major changes for the tests extension runs from WCAG 2.0AA to WCAG 2.1AA. What do you think?