### PR TITLE
Automate publishing workflow with release PR and tag-based PyPI/npm publishing

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "packages/extension": "0.2.7"
+}

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
+  "release-type": "node",
+  "packages": {
+    "packages/extension": {
+      "release-type": "node",
+      "package-name": "jupyterlab-a11y-checker",
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,100 @@
+name: Publish Extension
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+concurrency:
+  group: publish-extension-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Python build tools
+        run: python -m pip install --upgrade pip build twine "jupyterlab>=4.0.0,<5"
+
+      - name: Install dependencies and build extension assets
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+          YARN_CHECKSUM_BEHAVIOR: update
+        run: |
+          set -eux
+          jlpm install
+          npm run build -w packages/core
+          npm run build:prod -w packages/extension
+
+      - name: Check npm version status
+        id: npm_version
+        run: |
+          set -euo pipefail
+          LOCAL_VERSION=$(node -p "require('./packages/extension/package.json').version")
+          PUBLISHED_VERSION=$(npm view jupyterlab-a11y-checker version 2>/dev/null || true)
+
+          echo "local_version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "published_version=$PUBLISHED_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION is already on npm; npm publish will be skipped."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Will publish npm package version $LOCAL_VERSION."
+          fi
+
+      - name: Build Python package
+        working-directory: packages/extension
+        run: python -m build
+
+      - name: Publish to PyPI
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        working-directory: packages/extension
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --skip-existing dist/*
+
+      - name: Skip PyPI publish (missing token)
+        if: ${{ secrets.PYPI_API_TOKEN == '' }}
+        run: echo "PYPI_API_TOKEN is not configured. Skipping PyPI publish."
+
+      - name: Publish to npm
+        if: ${{ steps.npm_version.outputs.publish == 'true' && secrets.NPM_TOKEN != '' }}
+        working-directory: packages/extension
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Skip npm publish (already released or missing token)
+        if: ${{ steps.npm_version.outputs.publish != 'true' || secrets.NPM_TOKEN == '' }}
+        run: |
+          echo "Skipping npm publish."
+          echo "Local version: ${{ steps.npm_version.outputs.local_version }}"
+          echo "Published version: ${{ steps.npm_version.outputs.published_version }}"
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "NPM_TOKEN is not configured."
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,26 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          config-file: .github/release-please-config.json
+          manifest-file: .github/.release-please-manifest.json

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,41 @@
 
 The extension can be published to `PyPI` and `npm` manually or using the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).
 
+## Automated publish on merge
+
+This repository includes an automated, safer OSS release flow:
+
+- `.github/workflows/release-please.yml` runs on every push to `main` and manages a release PR.
+- When the release PR is merged, Release Please creates a Git tag (`vX.Y.Z`) and a GitHub Release.
+- `.github/workflows/publish-extension.yml` runs on `release.published` and publishes artifacts.
+
+This means normal feature merges do not immediately publish packages, but they do automatically advance release automation.
+
+Workflow files:
+
+- `.github/workflows/release-please.yml`
+- `.github/workflows/publish-extension.yml`
+- `.github/release-please-config.json`
+- `.github/.release-please-manifest.json`
+
+Publish targets:
+
+- PyPI package from `packages/extension`
+- npm package `jupyterlab-a11y-checker` from `packages/extension`
+
+Required repository secrets:
+
+- `PYPI_API_TOKEN`: PyPI token with publish permission.
+- `NPM_TOKEN`: npm automation token with publish permission for `jupyterlab-a11y-checker`.
+
+Notes:
+
+- Release tags follow the format `vX.Y.Z`.
+- The release PR is updated automatically as changes are merged into `main`.
+- npm publish is skipped when the local extension version is already published.
+- PyPI upload uses `--skip-existing`, so reruns are safe for already-published versions.
+- Publishing happens automatically after a release PR merge creates a tag/release.
+
 ## Manual release
 
 ### Python package


### PR DESCRIPTION
- Creates a release PR when changes are merged to main
- When the release PR gets merged, the extension gets published to PyPI/npm

The pypi and npm tokens need to be added to the secrets of this GitHub repo.