### PR TITLE
fix(deps): pin picomatch 4.x to 4.0.4 (POSIX char-class method injection)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7177,17 +7177,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 76b387b5157951422fa6049a96bdd1695e39dd126cd99df34d343638dc5cdb8bcdc83fff288c23eddcf7c26657c35e3173d4d5f488c4f28b889b314472e0a662
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 6817fb74eb745a71445debe1029768de55fd59a42b75606f478ee1d0dc1aa6e78b711d041a7c9d5550e042642029b7f373dc1a43b224c4b7f12d23436735dba0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Follow-up to #67. That PR fixed the **picomatch 2.x** line (→ `2.3.2`), but one consumer pins `picomatch@^4.0.3` and the lockfile stayed at `4.0.3` — still within range of the **"Picomatch: Method Injection in POSIX Character Classes"** advisory (`>=4.0.0 <4.0.4`). This scope-pins `^4.0.3` up to `4.0.4`.

## Why it slipped past #67

`yarn npm audit --all --recursive` reported clean (npm's advisory DB doesn't flag the 4.0.3 instance the same way), but **GitHub Dependabot's database does** flag it. Verified the residual with `yarn why picomatch` (a `4.0.3` node remained).

## Change

- `yarn.lock` only — `picomatch` `^4.0.3` descriptor pinned to `4.0.4` (via `yarn set resolution`). The `4.x` line now uniformly resolves to `4.0.4`; the `2.x` pin from #67 is unchanged.

## Verification

- `yarn why picomatch` → no `4.0.3` remaining; all `4.x` → `4.0.4`
- `yarn npm audit --all --recursive` → No audit suggestions
- `packages/core` tests: 50/50 pass; `core` + `cli` build clean
- picomatch is build-tooling only (file-watch globbing) — not shipped in cli/extension; patch bump, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)