### PR TITLE
fix(ci): adjust docs rules path

### DIFF
--- a/packages/cli/src/ruleDescriptions.ts
+++ b/packages/cli/src/ruleDescriptions.ts
@@ -6,7 +6,7 @@ export interface IRuleDescription {
   severity?: string;
 }
 
-import rulesContent from "../../../doc/rules.md";
+import rulesContent from "../../../docs/components/rules.md";
 
 function parseRuleLines(contents: string): Record<string, IRuleDescription> {
   const lines = contents.split(/\r?\n/);


### PR DESCRIPTION
It looks like the build is failing in #70 because of `ERROR: Could not resolve "../../../doc/rules.md"` I'm not seeing a `rules.md` file there but there is a `docs/components/rules.md`. Looks like Ryan  probably shifted this around last week in bf3b1d53f4ffb999943ea2f7af9d27168cfbf80e.