### PR TITLE
Fix outdated URLs after repo migration to berkeley-cdss

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Users can use this tool in three ways:
 
 ## Core Detection Engine
 
-While there are many possible a11y issues in Jupyter Notebooks, we prioritized the issues discussed in a [accessibility study on Jupyter Notebooks](https://arxiv.org/pdf/2308.03241), as well as [accessibility guideline for developers](https://docs.google.com/spreadsheets/d/1TBE4BhcmAN2wQHGYSvRGGdyL2pWTVw4cLFU3mARMfjM/edit?gid=0#gid=0). The core issues we detect are listed in [Rule Description](./doc/rules.md).
+While there are many possible a11y issues in Jupyter Notebooks, we prioritized the issues discussed in a [accessibility study on Jupyter Notebooks](https://arxiv.org/pdf/2308.03241), as well as [accessibility guideline for developers](https://docs.google.com/spreadsheets/d/1TBE4BhcmAN2wQHGYSvRGGdyL2pWTVw4cLFU3mARMfjM/edit?gid=0#gid=0). The core issues we detect are listed in [Rule Description](./docs/components/rules.md).
 
-Our detection engine relies on custom detection logic. In addition, we integrate [axe-core](https://github.com/dequelabs/axe-core) to detect other standard accessibility issues beyond these main issues, listed in [Axe Rule Description](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md). For details on why we use custom detection over axe-core for our core rules, see [Notes on Detection](./doc/notes-on-detection.md). Currently, axe is supported in the extension but not in the CLI tool.
+Our detection engine relies on custom detection logic. In addition, we integrate [axe-core](https://github.com/dequelabs/axe-core) to detect other standard accessibility issues beyond these main issues, listed in [Axe Rule Description](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md). For details on why we use custom detection over axe-core for our core rules, see [Notes on Detection](./docs/notes-on-detection.md). Currently, axe is supported in the extension but not in the CLI tool.
 
 ## JupyterLab Extension
 

--- a/agents.md
+++ b/agents.md
@@ -259,8 +259,8 @@ When issues are found, agents should:
 
 ## Resources
 
-- **Rule Descriptions**: https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker/blob/main/doc/rules.md
-- **GitHub Repository**: https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker
+- **Rule Descriptions**: https://github.com/berkeley-cdss/jupyterlab-a11y-checker/blob/main/docs/components/rules.md
+- **GitHub Repository**: https://github.com/berkeley-cdss/jupyterlab-a11y-checker
 - **PyPI Package**: https://pypi.org/project/jupyterlab-a11y-checker/
 - **NPM Package**: https://www.npmjs.com/package/@jupyterlab-a11y-checker/cli
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "repository": {
         "type": "git",
-        "url": "https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker.git",
+        "url": "https://github.com/berkeley-cdss/jupyterlab-a11y-checker.git",
         "directory": "packages/cli"
     },
     "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -155,7 +155,7 @@ program
         );
         console.log(
           chalk.blue(
-            "\nLearn more about the issues? Check out issue descriptions at https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker/blob/main/doc/rules.md",
+            "\nLearn more about the issues? Check out issue descriptions at https://github.com/berkeley-cdss/jupyterlab-a11y-checker/blob/main/docs/components/rules.md",
           ),
         );
         console.log(

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -12,7 +12,7 @@ Here's how the extension looks like:
 
 ### Issue Detection
 
-While there are many possible a11y issues in Jupyter Notebooks, we prioritized the issues discussed in a study on Jupyter Notebooks, [Notably Inaccessible — Data Driven Understanding of Data Science Notebook (In)Accessibility](https://arxiv.org/pdf/2308.03241). To address them, we implement custom detection logic for the issues listed in [Rule Description](./doc/rules.md). In addition, we integrate axe-core to detect other standard accessibility issues beyond these main issues, which are listed in [Axe Rule Description](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md).
+While there are many possible a11y issues in Jupyter Notebooks, we prioritized the issues discussed in a study on Jupyter Notebooks, [Notably Inaccessible — Data Driven Understanding of Data Science Notebook (In)Accessibility](https://arxiv.org/pdf/2308.03241). To address them, we implement custom detection logic for the issues listed in [Rule Description](./docs/components/rules.md). In addition, we integrate axe-core to detect other standard accessibility issues beyond these main issues, which are listed in [Axe Rule Description](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md).
 
 ### Issue Resolution
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -8,9 +8,9 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker",
+    "homepage": "https://github.com/berkeley-cdss/jupyterlab-a11y-checker",
     "bugs": {
-        "url": "https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker/issues"
+        "url": "https://github.com/berkeley-cdss/jupyterlab-a11y-checker/issues"
     },
     "license": "BSD-3-Clause",
     "author": "Research, Teaching, and Learning at UC Berkeley",
@@ -24,7 +24,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker.git",
+        "url": "https://github.com/berkeley-cdss/jupyterlab-a11y-checker.git",
         "directory": "packages/extension"
     },
     "scripts": {


### PR DESCRIPTION
Some documentation links got messed up after the repo was migrated from berkeley-dsep-infra to berkeley-cdss. Fixes https://github.com/berkeley-cdss/jupyterlab-a11y-checker/issues/80